### PR TITLE
09/19 2번째 커밋 로그인 (리턴으로 토큰값 헤더에 넣기) 테스트 성공

### DIFF
--- a/kh_final/src/main/java/com/kh/kh_final/member/user/commonUser/dto/CommonUserRespDto.java
+++ b/kh_final/src/main/java/com/kh/kh_final/member/user/commonUser/dto/CommonUserRespDto.java
@@ -2,6 +2,7 @@ package com.kh.kh_final.member.user.commonUser.dto;
 
 import com.kh.kh_final.member.user.commonUser.entity.CommonUserEntity;
 import com.kh.kh_final.member.user.common.enums.ApproveState;
+import com.kh.kh_final.member.user.security.CommonUserDetails;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -18,17 +19,18 @@ public class CommonUserRespDto {
     private LocalDateTime commonUpdateDate;
     private ApproveState approveState;
 
-    public static CommonUserRespDto from(CommonUserEntity entity) {
+    public static CommonUserRespDto from(CommonUserDetails userDetails) {
         CommonUserRespDto commonUserRespDto = new CommonUserRespDto();
-        commonUserRespDto.commonId = entity.getCommonId();
-        commonUserRespDto.commonNickName = entity.getCommonNickName();
-        commonUserRespDto.commonName = entity.getCommonName();
-        commonUserRespDto.commonEmail = entity.getCommonUserEmail();
-        commonUserRespDto.commonPhoneNumber = entity.getCommonPhoneNumber();
-        commonUserRespDto.commonAddress = entity.getCommonAddress();
-        commonUserRespDto.commonJoinDate = entity.getCommonJoinDate();
-        commonUserRespDto.commonUpdateDate = entity.getCommonUpdateDate();
-        commonUserRespDto.approveState = entity.getApproveState();
+        commonUserRespDto.commonId = userDetails.getCommonId();
+        commonUserRespDto.commonNickName = userDetails.getCommonNickName();
+        commonUserRespDto.commonName = userDetails.getCommonName();
+        commonUserRespDto.commonEmail = userDetails.getCommonUserEmail();
+        commonUserRespDto.commonPhoneNumber = userDetails.getCommonPhoneNumber();
+        commonUserRespDto.commonAddress = userDetails.getCommonAddress();
+        commonUserRespDto.commonJoinDate = userDetails.getCommonJoinDate();
+        commonUserRespDto.commonUpdateDate = userDetails.getCommonUpdateDate();
+        commonUserRespDto.approveState = userDetails.getApproveState();
         return commonUserRespDto;
     }
+
 }

--- a/kh_final/src/main/java/com/kh/kh_final/member/user/security/CommonUserDetails.java
+++ b/kh_final/src/main/java/com/kh/kh_final/member/user/security/CommonUserDetails.java
@@ -1,15 +1,19 @@
 package com.kh.kh_final.member.user.security;
 
+import com.kh.kh_final.member.user.common.enums.ApproveState;
 import com.kh.kh_final.member.user.commonUser.entity.CommonUserEntity;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 
 @RequiredArgsConstructor
+@Getter
 public class CommonUserDetails implements UserDetails {
     private final CommonUserEntity entity;
 
@@ -26,5 +30,42 @@ public class CommonUserDetails implements UserDetails {
     @Override
     public String getUsername() {
         return entity.getCommonId();
+    }
+
+
+    public String getCommonId() {
+        return entity.getCommonId();
+    }
+
+    public String getCommonNickName() {
+        return entity.getCommonNickName();
+    }
+
+    public String getCommonName() {
+        return entity.getCommonName();
+    }
+
+    public String getCommonUserEmail() {
+        return entity.getCommonUserEmail();
+    }
+
+    public String getCommonPhoneNumber() {
+        return entity.getCommonPhoneNumber();
+    }
+
+    public String getCommonAddress() {
+        return entity.getCommonAddress();
+    }
+
+    public LocalDateTime getCommonJoinDate() {
+        return entity.getCommonJoinDate();
+    }
+
+    public LocalDateTime getCommonUpdateDate() {
+        return entity.getCommonUpdateDate();
+    }
+
+    public ApproveState getApproveState() {
+        return entity.getApproveState();
     }
 }


### PR DESCRIPTION
[add] 유저디테일즈에 엔티티값 반환해주는 게터 생성
[add] LocalDateTime 값 사용하기 위해 JACKON에 모듈 추가
[add] respDto에 from 전역 메서드 추가 유저 디테일 -> respDto
[test] 회원가입 기능 정상작동 DB에 잘들어감, 로그인 기능 정상작동 토큰 생성되어 헤더에 담기고 바디에 DTO값 잘나옴.(password 없음 , 재직 증명서 없음)